### PR TITLE
Rollback to 4.14 patch version for s5p4418

### DIFF
--- a/target/linux/nexell-s5p4418/Makefile
+++ b/target/linux/nexell-s5p4418/Makefile
@@ -14,7 +14,7 @@ CPU_TYPE:=cortex-a9
 CPU_SUBTYPE:=neon
 MAINTAINER:=FriendlyARM <support@friendlyarm.com>
 
-KERNEL_PATCHVER:=4.19
+KERNEL_PATCHVER:=4.14
 
 
 define Target/Description


### PR DESCRIPTION
This fix made FriendlyWRT v19.07.1 works on s5p4418 again, tested to build with default configs `/build.sh nanopi_fire2a.mk`