### PR TITLE
Update 12-disable-rk3328-eth-offloading

### DIFF
--- a/target/linux/rockchip-rk3328/base-files/etc/hotplug.d/iface/12-disable-rk3328-eth-offloading
+++ b/target/linux/rockchip-rk3328/base-files/etc/hotplug.d/iface/12-disable-rk3328-eth-offloading
@@ -4,7 +4,7 @@
 . /lib/functions/network.sh
 
 [ -n "$INTERFACE" ] || exit 3
-[ "$INTERFACE" == "wan" ] || exit 4
+[ "$(uci get network.$INTERFACE.ifname)" == "eth0" ] || exit 4
 [ "$ACTION" == "ifup" ] || exit 1
 
 BOARD=$(cat /tmp/sysinfo/board_name | cut -d , -f2)


### PR DESCRIPTION
交换过 wan 和 lan 后 `"$INTERFACE" == "wan"` 不再有效