### PR TITLE
rockchip: update default sysctl conf

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/sysctl.d/31-optmize-proxy.conf
+++ b/target/linux/rockchip/armv8/base-files/etc/sysctl.d/31-optmize-proxy.conf
@@ -3,11 +3,6 @@ net.core.rmem_max = 67108864
 # max write buffer
 net.core.wmem_max = 67108864
 
-# short FIN timeout
-net.ipv4.tcp_fin_timeout = 30
-# short keepalive time
-net.ipv4.tcp_keepalive_time = 1200
-
 # outbound port range
 net.ipv4.ip_local_port_range = 10000 65535
 


### PR DESCRIPTION
1. The value of `net.ipv4.tcp_fin_timeout` is 30 by default, no need to change
2. The default value of `net.ipv4.tcp_keepalive_time` is 120, more shorter than 1200