### PR TITLE
rockchip: don't allow forward by default

### DIFF
--- a/target/linux/rockchip/armv8/base-files/root/setup.sh
+++ b/target/linux/rockchip/armv8/base-files/root/setup.sh
@@ -35,7 +35,7 @@ function init_firewall_ipv6() {
 function init_firewall() {
 	uci set firewall.@defaults[0].input='ACCEPT'
 	uci set firewall.@defaults[0].output='ACCEPT'
-	uci set firewall.@defaults[0].forward='ACCEPT'
+	uci set firewall.@defaults[0].forward='REJECT'
 
 	case "$boardname" in
 	nanopi-r5s | nanopi-r2s | nanopi-r2)


### PR DESCRIPTION
For security
Same as the official OpenWrt, only allowed in zone lan