### PR TITLE
rockchip: don't set static ula_prefix

### DIFF
--- a/target/linux/rockchip/armv8/base-files/root/setup.sh
+++ b/target/linux/rockchip/armv8/base-files/root/setup.sh
@@ -69,8 +69,12 @@ function init_firewall() {
 }
 
 function init_network() {
-	uci set network.globals.ula_prefix='fd00:ab:cd::/48'
-	uci commit network
+    local r1 r2 r3
+    r1=$(dd if=/dev/urandom bs=1 count=1 | hexdump -e '1/1 "%02x"')
+    r2=$(dd if=/dev/urandom bs=2 count=1 | hexdump -e '2/1 "%02x"')
+    r3=$(dd if=/dev/urandom bs=2 count=1 | hexdump -e '2/1 "%02x"')
+    uci set network.globals.ula_prefix="fd$r1:$r2:$r3::/48"
+    uci commit network
 }
 
 function init_nft-qos() {


### PR DESCRIPTION
Randomize it like https://github.com/friendlyarm/friendlywrt/blob/96e1d6736c9dbc690cf3745c6493f87f87d5e87c/package/base-files/files/etc/uci-defaults/12_network-generate-ula#L3-L10